### PR TITLE
style: use more descriptive suppression comments in producer/base

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -5,9 +5,6 @@ version: '{build}'
 branches:
   only:
     - master
-cache:
-  - .jest-cache
-  - node_modules
 platform: x64
 environment:
   nodejs_version: 8

--- a/src/producer/base.js
+++ b/src/producer/base.js
@@ -6,12 +6,12 @@ export default class ProducerBase<T> implements Producer<T> {
   // eslint-disable-next-line prettier/prettier
   /*:: @@iterator: () => Iterator<T>; */
 
-  // $FlowFixMe
+  // $FlowIgnore
   get [Symbol.toStringTag](): string {
     return this.constructor.name
   }
 
-  // $FlowFixMe
+  // $FlowIgnore
   [Symbol.iterator](): Iterator<T> {
     return this
   }


### PR DESCRIPTION
`$FlowIgnore` should be used rather than `$FlowFixMe` because the suppressed errors are caused by limitations of flow rather than erroneous types.