### PR TITLE
feat: emit both commonjs and es modules from build

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,10 +1,11 @@
 {
   "name": "iter.js",
   "version": "0.0.1",
-  "main": "dist/index.js",
   "repository": "github:zacharygolba/iter.js",
   "author": "Zachary Golba <zachary.golba@postlight.com>",
   "license": "MIT",
+  "main": "dist/index.js",
+  "module": "dist/index.es.js",
   "scripts": {
     "bench": "node benches",
     "build": "rollup -c",

--- a/rollup.config.js
+++ b/rollup.config.js
@@ -6,10 +6,18 @@ import resolve from 'rollup-plugin-node-resolve'
 
 export default {
   input: path.join(__dirname, 'src', 'index.js'),
-  output: {
-    file: path.join(__dirname, 'dist', 'index.js'),
-    format: 'cjs',
-  },
+  output: [
+    {
+      file: path.join(__dirname, 'dist', 'index.js'),
+      format: 'cjs',
+      sourcemap: true,
+    },
+    {
+      file: path.join(__dirname, 'dist', 'index.es.js'),
+      format: 'es',
+      sourcemap: true,
+    },
+  ],
   plugins: [
     resolve(),
     babel(),


### PR DESCRIPTION
Also adds a `"module"` field to `package.json` per [this proposal](https://github.com/dherman/defense-of-dot-js/blob/master/proposal.md).