### PR TITLE
feat: add iter.of(...items) factory

### DIFF
--- a/examples/password-generator/index.js
+++ b/examples/password-generator/index.js
@@ -9,7 +9,7 @@ module.exports = function generate(length = LENGTH, pattern = PATTERN) {
       // create an inifinitely repeating iterator of all valid chars [0-9A-Za-z]
       .cycle(
         iter
-          .from()
+          .of()
           .chain(iter.chars('0', '9'))
           .chain(iter.chars('A', 'Z'))
           .chain(iter.chars('a', 'z'))

--- a/src/__tests__/__snapshots__/index.js.snap
+++ b/src/__tests__/__snapshots__/index.js.snap
@@ -1,0 +1,13 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`#of() 1`] = `
+IndexedProducer {
+  "size": 3,
+  "source": Array [
+    1,
+    2,
+    3,
+  ],
+  "state": 0,
+}
+`;

--- a/src/__tests__/index.js
+++ b/src/__tests__/index.js
@@ -16,6 +16,17 @@ test('#from()', () => {
   expect(iter.from([1, 2, 3])).toBeInstanceOf(Iter)
 })
 
+test('#of()', () => {
+  expect(iter.of()).toBeInstanceOf(Iter)
+
+  {
+    const it = iter.of(1, 2, 3)
+
+    expect(it).toBeInstanceOf(Iter)
+    expect(it.producer).toMatchSnapshot()
+  }
+})
+
 test('#range()', () => {
   expect(iter.range()).toBeInstanceOf(Iter)
   expect(iter.range(1)).toBeInstanceOf(Iter)

--- a/src/__tests__/iter.js
+++ b/src/__tests__/iter.js
@@ -30,7 +30,7 @@ describe('Combinators', () => {
 
   test('#chain()', () => {
     const source = [4, 5, 6]
-    const subj = iter.from([1, 2, 3])
+    const subj = iter.of(1, 2, 3)
 
     subj.chain(source)
     expect(ChainAdapter).toHaveBeenLastCalledWith(subj.producer, source)
@@ -235,7 +235,7 @@ describe('Methods', () => {
   })
 
   test('#product()', () => {
-    expect(iter.from([]).product()).toBe(0)
+    expect(iter.of().product()).toBe(0)
     expect(iter.range(2, 4).product()).toBe(2 * 3 * 4)
     expect(Number.isNaN(iter.chars('a', 'z').product())).toBe(true)
   })
@@ -266,12 +266,12 @@ describe('Methods', () => {
   })
 
   test('#sum()', () => {
-    expect(iter.from([]).sum()).toBe(0)
+    expect(iter.of().sum()).toBe(0)
     expect(iter.range(1, 4).sum()).toBe(1 + 2 + 3 + 4)
     expect(Number.isNaN(iter.chars('a', 'z').sum())).toBe(true)
   })
 
   test('#toString()', () => {
-    expect(iter.from([]).toString()).toBe('[object Iter]')
+    expect(iter.of().toString()).toBe('[object Iter]')
   })
 })

--- a/src/adapter/__tests__/chain.js
+++ b/src/adapter/__tests__/chain.js
@@ -6,8 +6,8 @@ import * as iter from '../../'
 let subj
 
 beforeEach(() => {
-  const producerA = iter.from([1, 2, 3]).producer
-  const producerB = iter.from([4, 5, 6]).producer
+  const producerA = iter.of(1, 2, 3).producer
+  const producerB = iter.of(4, 5, 6).producer
   subj = new Chain(producerA, producerB)
 })
 

--- a/src/adapter/__tests__/enumerate.js
+++ b/src/adapter/__tests__/enumerate.js
@@ -6,7 +6,7 @@ import * as iter from '../../'
 let subj
 
 beforeEach(() => {
-  const { producer } = iter.from([1, 2, 3])
+  const { producer } = iter.of(1, 2, 3)
   subj = new Enumerate(producer)
 })
 

--- a/src/adapter/__tests__/filter-map.js
+++ b/src/adapter/__tests__/filter-map.js
@@ -6,7 +6,7 @@ import * as iter from '../../'
 let subj
 
 beforeEach(() => {
-  const { producer } = iter.from([1, null, 2, undefined, 3])
+  const { producer } = iter.of(1, null, 2, undefined, 3)
   subj = new FilterMap(producer, value => value)
 })
 

--- a/src/adapter/__tests__/filter.js
+++ b/src/adapter/__tests__/filter.js
@@ -6,7 +6,7 @@ import * as iter from '../../'
 let subj
 
 beforeEach(() => {
-  const { producer } = iter.from([1, 2, 3])
+  const { producer } = iter.of(1, 2, 3)
   subj = new Filter(producer, value => value > 1)
 })
 

--- a/src/adapter/__tests__/flat-map.js
+++ b/src/adapter/__tests__/flat-map.js
@@ -6,7 +6,7 @@ import * as iter from '../../'
 let subj
 
 beforeEach(() => {
-  const { producer } = iter.from([1, 2, 3])
+  const { producer } = iter.of(1, 2, 3)
   subj = new FlatMap(producer, item => iter.repeat(item).take(2))
 })
 

--- a/src/adapter/__tests__/map.js
+++ b/src/adapter/__tests__/map.js
@@ -6,7 +6,7 @@ import * as iter from '../../'
 let subj
 
 beforeEach(() => {
-  const { producer } = iter.from([1, 2, 3])
+  const { producer } = iter.of(1, 2, 3)
   subj = new Map(producer, value => value * 2)
 })
 

--- a/src/adapter/__tests__/skip-while.js
+++ b/src/adapter/__tests__/skip-while.js
@@ -6,7 +6,7 @@ import * as iter from '../../'
 let subj
 
 beforeEach(() => {
-  const { producer } = iter.from([1, 2, 3, 4, 5, 6])
+  const { producer } = iter.of(1, 2, 3, 4, 5, 6)
   subj = new SkipWhile(producer, value => value <= 3)
 })
 

--- a/src/adapter/__tests__/skip.js
+++ b/src/adapter/__tests__/skip.js
@@ -6,7 +6,7 @@ import * as iter from '../../'
 let subj
 
 beforeEach(() => {
-  const { producer } = iter.from([1, 2, 3, 4, 5, 6])
+  const { producer } = iter.of(1, 2, 3, 4, 5, 6)
   subj = new Skip(producer, 3)
 })
 

--- a/src/adapter/__tests__/take-while.js
+++ b/src/adapter/__tests__/take-while.js
@@ -6,7 +6,7 @@ import * as iter from '../../'
 let subj
 
 beforeEach(() => {
-  const { producer } = iter.from([1, 2, 3, 4, 5, 6])
+  const { producer } = iter.of(1, 2, 3, 4, 5, 6)
   subj = new TakeWhile(producer, value => value <= 3)
 })
 

--- a/src/adapter/__tests__/tap.js
+++ b/src/adapter/__tests__/tap.js
@@ -7,7 +7,7 @@ const fn = jest.fn()
 let subj
 
 beforeEach(() => {
-  const { producer } = iter.from([1, 2, 3])
+  const { producer } = iter.of(1, 2, 3)
   subj = new Tap(producer, fn)
 })
 

--- a/src/adapter/__tests__/zip.js
+++ b/src/adapter/__tests__/zip.js
@@ -7,7 +7,7 @@ let subj
 
 beforeEach(() => {
   const producerA = iter.repeat('test').producer
-  const producerB = iter.from([1, 2, 3]).producer
+  const producerB = iter.of(1, 2, 3).producer
   subj = new Zip(producerA, producerB)
 })
 
@@ -26,7 +26,7 @@ describe('#next()', () => {
   })
 
   test('with a bound lhs and an unbound rhs', () => {
-    const producerA = iter.from([1, 2, 3]).producer
+    const producerA = iter.of(1, 2, 3).producer
     const producerB = iter.repeat('test').producer
     subj = new Zip(producerA, producerB)
 
@@ -37,7 +37,7 @@ describe('#next()', () => {
   })
 
   test('with a self reference to bound lhs', () => {
-    const { producer } = iter.from([1, 2, 3, 4])
+    const { producer } = iter.of(1, 2, 3, 4)
     subj = new Zip(producer, producer)
 
     expect(subj.next()).toMatchSnapshot()
@@ -53,7 +53,7 @@ describe('#sizeHint()', () => {
   })
 
   test('with a bound lhs and an unbound rhs', () => {
-    const producerA = iter.from([1, 2, 3]).producer
+    const producerA = iter.of(1, 2, 3).producer
     const producerB = iter.repeat('test').producer
     subj = new Zip(producerA, producerB)
 
@@ -70,14 +70,14 @@ describe('#sizeHint()', () => {
 
   test('with a self reference to bound lhs', () => {
     {
-      const { producer } = iter.from([1, 2, 3])
+      const { producer } = iter.of(1, 2, 3)
       subj = new Zip(producer, producer)
     }
 
     expect(subj.sizeHint()).toBe(1)
 
     {
-      const { producer } = iter.from([1, 2, 3, 4])
+      const { producer } = iter.of(1, 2, 3, 4)
       subj = new Zip(producer, producer)
     }
 

--- a/src/index.js
+++ b/src/index.js
@@ -7,6 +7,7 @@ import {
   createProducer,
   CharProducer,
   CycleProducer,
+  IndexedProducer,
   NumberProducer,
   RepeatProducer,
 } from './producer'
@@ -28,6 +29,11 @@ export function cycle<T>(source: IndexedCollection<T>): Iter<T> {
 
 export function from<T>(source?: Iterable<T> | T = []): Iter<T> {
   const producer = createProducer(source)
+  return new Iter(producer)
+}
+
+export function of<T>(...items: Array<T>): Iter<T> {
+  const producer = new IndexedProducer(items)
   return new Iter(producer)
 }
 


### PR DESCRIPTION
It is nice to not have to use an array literal when you have a static set of values that you want to feed into an iterator.

#### Example

```javascript
import * as iter from 'iter.js'

iter.from([1, 2, 3]).forEach(num => console.log(num))
// => 1
// => 2
// => 3

iter.of(1, 2, 3).forEach(num => console.log(num))
// => 1
// => 2
// => 3
```

It is also beneficial to have a method that doesn't try to coerce the input into an iterator itself. This is particularly beneficial with strings.

#### Example

```javascript
import * as iter from 'iter.js'

iter.from('abc').forEach(char => console.log(char))
// => 'a'
// => 'b'
// => 'c'

iter.of('abc').forEach(str => console.log(str))
// => 'abc
```
