### PR TITLE
feat: cache size when reducing an iterator

### DIFF
--- a/src/__tests__/iter.js
+++ b/src/__tests__/iter.js
@@ -165,7 +165,6 @@ describe('Methods', () => {
 
   test('#count()', () => {
     expect(iter.range(1, 10).count()).toBe(10)
-    expect(iter.range(1).count()).toBe(Infinity)
   })
 
   test('#every()', () => {

--- a/src/adapter/__tests__/flat-map.js
+++ b/src/adapter/__tests__/flat-map.js
@@ -27,11 +27,5 @@ test('#next()', () => {
 })
 
 test('#sizeHint()', () => {
-  expect(subj.sizeHint()).toEqual(3)
-
-  // eslint-disable-next-line no-empty, no-unused-vars
-  for (const _ of subj) {
-  }
-
-  expect(subj.sizeHint()).toEqual(6)
+  expect(subj.sizeHint()).toEqual(Infinity)
 })

--- a/src/adapter/flat-map.js
+++ b/src/adapter/flat-map.js
@@ -8,13 +8,11 @@ export default class FlatMapAdapter<T, U> extends ProducerBase<U> {
   child: ?Producer<U>
   fn: T => Iterable<U> | U
   parent: Producer<T>
-  size: number
 
   constructor(producer: Producer<T>, fn: T => Iterable<U> | U) {
     super()
     this.fn = fn
     this.parent = producer
-    this.size = this.parent.sizeHint()
   }
 
   next(): IteratorResult<U, void> {
@@ -28,10 +26,7 @@ export default class FlatMapAdapter<T, U> extends ProducerBase<U> {
       }
 
       const child = createProducer(this.fn(nextChild.value))
-
       this.child = child
-      this.size += child.sizeHint() - 1
-
       next = child.next()
     }
 
@@ -39,6 +34,6 @@ export default class FlatMapAdapter<T, U> extends ProducerBase<U> {
   }
 
   sizeHint(): number {
-    return this.size
+    return Infinity
   }
 }

--- a/src/iter.js
+++ b/src/iter.js
@@ -52,8 +52,7 @@ export default class Iter<T> extends ProducerBase<T> {
   }
 
   count(): number {
-    const size = this.sizeHint()
-    return Number.isFinite(size) ? this.reduce(acc => acc + 1, 0) : Infinity
+    return this.reduce(acc => acc + 1, 0)
   }
 
   enumerate(): Iter<[number, T]> {
@@ -139,9 +138,10 @@ export default class Iter<T> extends ProducerBase<T> {
 
   reduce(fn: (T, T) => T): T {}
   reduce<U>(fn: (U, T) => U, init: U): U {
+    const size = this.sizeHint()
     let acc = init
 
-    for (let i = 0; i < this.sizeHint(); i += 1) {
+    for (let i = 0; i < size; i += 1) {
       const result = this.next()
 
       if (result.done) {


### PR DESCRIPTION
For performance purposes we should cache the result of `#sizeHint()` when calling `#reduce()`. Previously we did not do this because the `FlatMapAdapter` is expected grow in size each time `#next()` is called.

As a result, `FlatMapAdapter#sizeHint()` now returns `Infinity` and some run-time checks to determine whether an iterator is finite are no longer in place, with the assumption that the consumer is responsible for collapsing the iterator down to a finite size.