### PR TITLE
feat: add iife to build output formats

### DIFF
--- a/rollup.config.js
+++ b/rollup.config.js
@@ -17,6 +17,12 @@ export default {
       format: 'es',
       sourcemap: true,
     },
+    {
+      file: path.join(__dirname, 'dist', 'index.iife.js'),
+      format: 'iife',
+      name: 'iter',
+      sourcemap: true,
+    },
   ],
   plugins: [json(), babel(), resolve()],
   preferConst: true,


### PR DESCRIPTION
It's nice to have an `iife` emitted from the build process if you want to test in a browser without using a module bundler.