### PR TITLE
refactor: remove abnormal logic in skip while adapter

### DIFF
--- a/src/adapter/skip-while.js
+++ b/src/adapter/skip-while.js
@@ -22,6 +22,6 @@ export default class SkipWhileAdapter<T> extends ProducerBase<T> {
     }
 
     this.skipped = !this.fn(next.value)
-    return this.next()
+    return this.skipped ? next : this.next()
   }
 }

--- a/src/adapter/skip-while.js
+++ b/src/adapter/skip-while.js
@@ -2,27 +2,26 @@
 
 import { ProducerBase } from '../producer'
 
-import Filter from './filter'
-
 export default class SkipWhileAdapter<T> extends ProducerBase<T> {
+  fn: T => boolean
   producer: Iterator<T>
+  skipped: boolean
 
   constructor(producer: Iterator<T>, fn: T => boolean) {
     super()
-
-    let willSkip = true
-
-    this.producer = new Filter(producer, value => {
-      if (willSkip) {
-        willSkip = fn(value)
-        return !willSkip
-      }
-
-      return true
-    })
+    this.fn = fn
+    this.producer = producer
+    this.skipped = false
   }
 
   next(): IteratorResult<T, void> {
-    return this.producer.next()
+    const next = this.producer.next()
+
+    if (next.done || this.skipped) {
+      return next
+    }
+
+    this.skipped = !this.fn(next.value)
+    return this.next()
   }
 }

--- a/src/adapter/skip.js
+++ b/src/adapter/skip.js
@@ -5,20 +5,20 @@ import { ProducerBase } from '../producer'
 export default class SkipAdapter<T> extends ProducerBase<T> {
   amount: number
   producer: Iterator<T>
-  state: number
+  calls: number
 
   constructor(producer: Iterator<T>, amount: number) {
     super()
     this.amount = amount
+    this.calls = 0
     this.producer = producer
-    this.state = 0
   }
 
   next(): IteratorResult<T, void> {
     const next = this.producer.next()
 
-    if (this.state < this.amount) {
-      this.state += 1
+    if (this.calls < this.amount) {
+      this.calls += 1
       return this.next()
     }
 


### PR DESCRIPTION
Adapters should not compose internally outside the context of `Iter`.