### PR TITLE
chore: remove unhelpful comment

### DIFF
--- a/src/iter.js
+++ b/src/iter.js
@@ -123,8 +123,6 @@ export default class Iter<T> extends ProducerBase<T> {
       return value
     }
 
-    // If the last index is not equal to the input index, the input index was
-    // out of bounds.
     return undefined
   }
 


### PR DESCRIPTION
This comment isn't very helpful. It is pretty obvious that a bounds check is happening when the indices are compared.